### PR TITLE
Minor Docblock fixes for @param and @return tags

### DIFF
--- a/src/Contracts/Restable.php
+++ b/src/Contracts/Restable.php
@@ -14,7 +14,7 @@ interface Restable {
      * Response listing.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function listing($messages);
 
@@ -22,7 +22,7 @@ interface Restable {
      * Response single.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function single($messages);
 
@@ -30,7 +30,7 @@ interface Restable {
      * Response created.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function created($messages);
 
@@ -38,15 +38,14 @@ interface Restable {
      * Response updated.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function updated($messages);
 
     /**
      * Response deleted.
      *
-     * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function deleted();
 
@@ -62,7 +61,8 @@ interface Restable {
      * Response error.
      *
      * @param  array  $messages
-     * @return string
+     * @param  int   $type
+     * @return \Teepluss\Restable\Restable
      */
     public function error($messages, $type = 400);
 
@@ -70,7 +70,7 @@ interface Restable {
      * Unauthorized.
      *
      * @param  mixed $description
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function unauthorized($description = null);
 
@@ -78,7 +78,7 @@ interface Restable {
      * Any error return 400 as bad request.
      *
      * @param  mixed  $description
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function bad($description = null);
 
@@ -86,7 +86,7 @@ interface Restable {
      * Alias of error 404 response.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function missing($description = null);
 
@@ -94,14 +94,15 @@ interface Restable {
      * Alias of error 422 response.
      *
      * @param  array  $error
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function unprocess($errors);
 
     /**
      * Render response with format.
      *
-     * @param  string $format
+     * @param  string         $format
+     * @param  null|callable  $callback
      * @return mixed
      */
     public function render($format = null, $callback = null);

--- a/src/Contracts/Restable.php
+++ b/src/Contracts/Restable.php
@@ -103,7 +103,7 @@ interface Restable {
      *
      * @param  string         $format
      * @param  null|callable  $callback
-     * @return mixed
+     * @return mixed|\Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function render($format = null, $callback = null);
 

--- a/src/Contracts/Restable.php
+++ b/src/Contracts/Restable.php
@@ -13,7 +13,7 @@ interface Restable {
     /**
      * Response listing.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function listing($messages);
@@ -21,7 +21,7 @@ interface Restable {
     /**
      * Response single.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function single($messages);
@@ -29,7 +29,7 @@ interface Restable {
     /**
      * Response created.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function created($messages);
@@ -37,7 +37,7 @@ interface Restable {
     /**
      * Response updated.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function updated($messages);
@@ -60,7 +60,7 @@ interface Restable {
     /**
      * Response error.
      *
-     * @param  array  $messages
+     * @param  mixed $messages
      * @param  int   $type
      * @return \Teepluss\Restable\Restable
      */
@@ -85,7 +85,7 @@ interface Restable {
     /**
      * Alias of error 404 response.
      *
-     * @param  array  $messages
+     * @param  string  $description
      * @return \Teepluss\Restable\Restable
      */
     public function missing($description = null);
@@ -93,7 +93,7 @@ interface Restable {
     /**
      * Alias of error 422 response.
      *
-     * @param  array  $error
+     * @param  mixed  $errors
      * @return \Teepluss\Restable\Restable
      */
     public function unprocess($errors);

--- a/src/Restable.php
+++ b/src/Restable.php
@@ -90,7 +90,7 @@ class Restable implements RestableContract {
     /**
      * Making response.
      *
-     * @param  array  $data
+     * @param  mixed  $data
      * @param  string $type
      * @return \Teepluss\Restable\Restable
      */
@@ -141,7 +141,7 @@ class Restable implements RestableContract {
     /**
      * Response listing.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function listing($messages)
@@ -154,7 +154,7 @@ class Restable implements RestableContract {
     /**
      * Response single.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function single($messages)
@@ -167,7 +167,7 @@ class Restable implements RestableContract {
     /**
      * Response created.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function created($messages)
@@ -180,7 +180,7 @@ class Restable implements RestableContract {
     /**
      * Response updated.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return \Teepluss\Restable\Restable
      */
     public function updated($messages)
@@ -216,7 +216,7 @@ class Restable implements RestableContract {
     /**
      * Response error.
      *
-     * @param  array  $messages
+     * @param  mixed $messages
      * @param  int   $type
      * @return \Teepluss\Restable\Restable
      */
@@ -252,7 +252,7 @@ class Restable implements RestableContract {
     /**
      * Alias of error 404 response.
      *
-     * @param  array  $messages
+     * @param  mixed $description
      * @return \Teepluss\Restable\Restable
      */
     public function missing($description = null)
@@ -263,7 +263,7 @@ class Restable implements RestableContract {
     /**
      * Alias of error 422 response.
      *
-     * @param  array  $error
+     * @param  mixed  $errors
      * @return \Teepluss\Restable\Restable
      */
     public function unprocess($errors)
@@ -274,7 +274,7 @@ class Restable implements RestableContract {
     /**
      * Validation error.
      *
-     * @param  array  $messages
+     * @param  mixed  $messages
      * @return string
      */
     protected function error_422($messages)

--- a/src/Restable.php
+++ b/src/Restable.php
@@ -312,7 +312,7 @@ class Restable implements RestableContract {
      *
      * @param  string         $format
      * @param  null|callable  $callback
-     * @return \Teepluss\Restable\Restable
+     * @return mixed|\Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function render($format = null, $callback = null)
     {

--- a/src/Restable.php
+++ b/src/Restable.php
@@ -142,7 +142,7 @@ class Restable implements RestableContract {
      * Response listing.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function listing($messages)
     {
@@ -155,7 +155,7 @@ class Restable implements RestableContract {
      * Response single.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function single($messages)
     {
@@ -168,7 +168,7 @@ class Restable implements RestableContract {
      * Response created.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function created($messages)
     {
@@ -181,7 +181,7 @@ class Restable implements RestableContract {
      * Response updated.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function updated($messages)
     {
@@ -193,8 +193,7 @@ class Restable implements RestableContract {
     /**
      * Response deleted.
      *
-     * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function deleted()
     {
@@ -205,7 +204,7 @@ class Restable implements RestableContract {
      * Simple response success.
      *
      * @param  mixed  $message
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function success($message)
     {
@@ -218,7 +217,8 @@ class Restable implements RestableContract {
      * Response error.
      *
      * @param  array  $messages
-     * @return string
+     * @param  int   $type
+     * @return \Teepluss\Restable\Restable
      */
     public function error($messages, $type = 400)
     {
@@ -231,7 +231,7 @@ class Restable implements RestableContract {
      * Unauthorized.
      *
      * @param  mixed $description
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function unauthorized($description = null)
     {
@@ -242,7 +242,7 @@ class Restable implements RestableContract {
      * Any error return 400 as bad request.
      *
      * @param  mixed  $description
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function bad($description = null)
     {
@@ -253,7 +253,7 @@ class Restable implements RestableContract {
      * Alias of error 404 response.
      *
      * @param  array  $messages
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function missing($description = null)
     {
@@ -264,7 +264,7 @@ class Restable implements RestableContract {
      * Alias of error 422 response.
      *
      * @param  array  $error
-     * @return string
+     * @return \Teepluss\Restable\Restable
      */
     public function unprocess($errors)
     {
@@ -310,8 +310,9 @@ class Restable implements RestableContract {
     /**
      * Render response with format.
      *
-     * @param  string $format
-     * @return mixed
+     * @param  string         $format
+     * @param  null|callable  $callback
+     * @return \Teepluss\Restable\Restable
      */
     public function render($format = null, $callback = null)
     {


### PR DESCRIPTION
PHPStorm (and other IDEs) tend to give incorrect warnings due to the incorrect doc blocks. This PR fixes the following:
- IDEs not understanding Restable fluent syntax (such as for `Restable::listing([])->render()`, fixed by updating the `listing()` @return tag).
- IDEs incorrectly warning that non-array parameters for many methods are not accepted (whereas objects with `toArray()` methods are supported).

These fixes _only_ affect doc blocks, no functionality or other comments are affected.
